### PR TITLE
Modelling user - feature

### DIFF
--- a/backend/alembic/versions/bc3b7e5e6d5d_create_users_table.py
+++ b/backend/alembic/versions/bc3b7e5e6d5d_create_users_table.py
@@ -1,0 +1,54 @@
+"""create users table
+
+Revision ID: bc3b7e5e6d5d
+Revises: 4bcd32a2d970
+Create Date: 2026-04-08 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "bc3b7e5e6d5d"
+down_revision: Union[str, None] = "4bcd32a2d970"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "users",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("email", sa.String(length=255), nullable=False),
+        sa.Column("password_hash", sa.String(length=255), nullable=False),
+        sa.Column(
+            "is_active",
+            sa.Boolean(),
+            server_default=sa.text("true"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("email"),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_table("users")

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -1,0 +1,3 @@
+from app.api.auth import router as auth_router
+
+__all__ = ["auth_router"]

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -1,0 +1,68 @@
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from sqlalchemy.orm import Session
+
+from app.core.database import get_db
+from app.core.security import decode_access_token
+from app.models import User
+from app.schemas import AuthTokenRead, UserCreate, UserLogin, UserRead
+from app.services import auth as auth_service
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login")
+
+
+def get_current_user(
+    token: str = Depends(oauth2_scheme),
+    db: Session = Depends(get_db),
+) -> User:
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials.",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+    try:
+        payload = decode_access_token(token)
+        user_id = payload.get("sub")
+        if not isinstance(user_id, str):
+            raise credentials_exception
+        current_user = auth_service.get_user_by_id(db, uuid.UUID(user_id))
+    except (ValueError, TypeError):
+        raise credentials_exception
+
+    if current_user is None or not current_user.is_active:
+        raise credentials_exception
+    return current_user
+
+
+@router.post("/register", response_model=UserRead, status_code=status.HTTP_201_CREATED)
+def register_user(user_in: UserCreate, db: Session = Depends(get_db)) -> UserRead:
+    try:
+        user = auth_service.create_user(db, user_in)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=str(exc),
+        ) from exc
+
+    return UserRead.model_validate(user)
+
+
+@router.post("/login", response_model=AuthTokenRead)
+def login_user(user_in: UserLogin, db: Session = Depends(get_db)) -> AuthTokenRead:
+    user = auth_service.authenticate_user(db, user_in.email, user_in.password)
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid email or password.",
+        )
+
+    return auth_service.build_auth_response(user)
+
+
+@router.get("/me", response_model=UserRead)
+def read_current_user(current_user: User = Depends(get_current_user)) -> UserRead:
+    return UserRead.model_validate(current_user)

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -1,0 +1,99 @@
+import base64
+import hashlib
+import hmac
+import json
+import os
+import secrets
+import time
+
+SECRET_KEY = os.getenv("AUTH_SECRET_KEY", "change-me-in-production")
+ACCESS_TOKEN_EXPIRE_MINUTES = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "60"))
+PASSWORD_HASH_ITERATIONS = 100_000
+
+def _urlsafe_b64encode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("utf-8")
+
+
+def _urlsafe_b64decode(data: str) -> bytes:
+    padding = "=" * (-len(data) % 4)
+    return base64.urlsafe_b64decode(data + padding)
+
+
+def hash_password(password: str) -> str:
+    salt = secrets.token_bytes(16)
+    derived_key = hashlib.pbkdf2_hmac(
+        "sha256", password.encode("utf-8"), salt, PASSWORD_HASH_ITERATIONS
+    )
+    return (
+        f"pbkdf2_sha256${PASSWORD_HASH_ITERATIONS}$"
+        f"{_urlsafe_b64encode(salt)}${_urlsafe_b64encode(derived_key)}"
+    )
+
+
+def verify_password(password: str, password_hash: str) -> bool:
+    try:
+        algorithm, iterations, salt, stored_hash = password_hash.split("$")
+    except ValueError:
+        return False
+
+    if algorithm != "pbkdf2_sha256":
+        return False
+
+    derived_key = hashlib.pbkdf2_hmac(
+        "sha256",
+        password.encode("utf-8"),
+        _urlsafe_b64decode(salt),
+        int(iterations),
+    )
+    return hmac.compare_digest(
+        _urlsafe_b64encode(derived_key),
+        stored_hash,
+    )
+
+
+def create_access_token(
+    subject: str, expires_in_minutes: int = ACCESS_TOKEN_EXPIRE_MINUTES
+) -> str:
+    header = {"alg": "HS256", "typ": "JWT"}
+    payload = {
+        "sub": subject,
+        "exp": int(time.time()) + expires_in_minutes * 60,
+    }
+
+    encoded_header = _urlsafe_b64encode(
+        json.dumps(header, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    )
+    encoded_payload = _urlsafe_b64encode(
+        json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    )
+    signature = hmac.new(
+        SECRET_KEY.encode("utf-8"),
+        f"{encoded_header}.{encoded_payload}".encode("utf-8"),
+        hashlib.sha256,
+    ).digest()
+    encoded_signature = _urlsafe_b64encode(signature)
+    return f"{encoded_header}.{encoded_payload}.{encoded_signature}"
+
+
+def decode_access_token(token: str) -> dict[str, object]:
+    try:
+        encoded_header, encoded_payload, encoded_signature = token.split(".")
+    except ValueError as exc:
+        raise ValueError("Invalid token format.") from exc
+
+    expected_signature = hmac.new(
+        SECRET_KEY.encode("utf-8"),
+        f"{encoded_header}.{encoded_payload}".encode("utf-8"),
+        hashlib.sha256,
+    ).digest()
+    if not hmac.compare_digest(
+        _urlsafe_b64encode(expected_signature),
+        encoded_signature,
+    ):
+        raise ValueError("Invalid token signature.")
+
+    payload = json.loads(_urlsafe_b64decode(encoded_payload).decode("utf-8"))
+    expires_at = payload.get("exp")
+    if not isinstance(expires_at, int) or expires_at < int(time.time()):
+        raise ValueError("Token has expired.")
+    return payload

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,11 @@
+from fastapi import FastAPI
+
+from app.api.auth import router as auth_router
+
+app = FastAPI(title="KULTI API")
+app.include_router(auth_router)
+
+
+@app.get("/health", tags=["health"])
+def read_health() -> dict[str, str]:
+    return {"status": "ok"}

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,3 +1,4 @@
+from app.models.user import User
 from app.models.venue import Venue
 
-__all__ = ["Venue"]
+__all__ = ["User", "Venue"]

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,0 +1,28 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, String, func, true
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    email: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
+    password_hash: Mapped[str] = mapped_column(String(255), nullable=False)
+    is_active: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default=true()
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,3 +1,12 @@
+from app.schemas.user import AuthTokenRead, UserCreate, UserLogin, UserRead
 from app.schemas.venue import VenueCreate, VenueRead, VenueUpdate
 
-__all__ = ["VenueCreate", "VenueRead", "VenueUpdate"]
+__all__ = [
+    "AuthTokenRead",
+    "UserCreate",
+    "UserLogin",
+    "UserRead",
+    "VenueCreate",
+    "VenueRead",
+    "VenueUpdate",
+]

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -1,0 +1,56 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class UserCreate(BaseModel):
+    name: str = Field(min_length=1, max_length=255)
+    email: str = Field(min_length=3, max_length=255)
+    password: str = Field(min_length=8, max_length=255)
+
+    @field_validator("name")
+    @classmethod
+    def normalize_name(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("Name cannot be empty.")
+        return normalized
+
+    @field_validator("email")
+    @classmethod
+    def normalize_email(cls, value: str) -> str:
+        normalized = value.strip().lower()
+        if not normalized:
+            raise ValueError("Email cannot be empty.")
+        return normalized
+
+
+class UserLogin(BaseModel):
+    email: str = Field(min_length=3, max_length=255)
+    password: str = Field(min_length=1, max_length=255)
+
+    @field_validator("email")
+    @classmethod
+    def normalize_email(cls, value: str) -> str:
+        normalized = value.strip().lower()
+        if not normalized:
+            raise ValueError("Email cannot be empty.")
+        return normalized
+
+
+class UserRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    name: str
+    email: str
+    is_active: bool
+    created_at: datetime
+    updated_at: datetime
+
+
+class AuthTokenRead(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+    user: UserRead

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,0 +1,3 @@
+from app.services import auth
+
+__all__ = ["auth"]

--- a/backend/app/services/auth.py
+++ b/backend/app/services/auth.py
@@ -1,0 +1,48 @@
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.core.security import create_access_token, hash_password, verify_password
+from app.models import User
+from app.schemas import AuthTokenRead, UserCreate, UserRead
+
+
+def get_user_by_email(db: Session, email: str) -> User | None:
+    normalized_email = email.strip().lower()
+    return db.scalar(select(User).where(User.email == normalized_email))
+
+
+def get_user_by_id(db: Session, user_id: uuid.UUID) -> User | None:
+    return db.get(User, user_id)
+
+
+def create_user(db: Session, user_in: UserCreate) -> User:
+    if get_user_by_email(db, user_in.email):
+        raise ValueError("A user with this email already exists.")
+
+    user = User(
+        name=user_in.name,
+        email=user_in.email,
+        password_hash=hash_password(user_in.password),
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def authenticate_user(db: Session, email: str, password: str) -> User | None:
+    user = get_user_by_email(db, email)
+    if user is None or not user.is_active:
+        return None
+    if not verify_password(password, user.password_hash):
+        return None
+    return user
+
+
+def build_auth_response(user: User) -> AuthTokenRead:
+    return AuthTokenRead(
+        access_token=create_access_token(str(user.id)),
+        user=UserRead.model_validate(user),
+    )

--- a/docs/ASSISTANT.md
+++ b/docs/ASSISTANT.md
@@ -15,6 +15,7 @@
 
 ### Setup & Infrastructure
 - `docs/setup/backend-setup.md` — Python venv, dependencies, running FastAPI
+- `docs/setup/auth-api.md` — Authentication endpoints and request/response examples
 - `docs/setup/docker-setup.md` — Docker Compose for PostgreSQL + PostGIS
 - `docs/setup/database-schema.md` — ER diagram, conventions, and column reference for all tables
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -7,6 +7,7 @@
 | File | Description |
 |------|-------------|
 | [backend-setup.md](setup/backend-setup.md) | Python venv setup, dependency install, and how to run the FastAPI server |
+| [auth-api.md](setup/auth-api.md) | Authentication endpoints and request/response examples |
 | [docker-setup.md](setup/docker-setup.md) | Docker Compose setup for the PostgreSQL + PostGIS database |
 | [database-schema.md](setup/database-schema.md) | ER diagram, conventions, and detailed column reference for all tables |
 

--- a/docs/setup/auth-api.md
+++ b/docs/setup/auth-api.md
@@ -1,0 +1,74 @@
+[← Back to Index](../INDEX.md)
+
+# Authentication API
+
+Base authentication endpoints for KULTI's first backend/frontend integration cycle.
+
+## Endpoints
+
+### POST `/auth/register`
+
+Creates a new user account.
+
+Request body:
+
+```json
+{
+  "name": "Ana Silva",
+  "email": "ana@email.com",
+  "password": "12345678"
+}
+```
+
+Response `201 Created`:
+
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "name": "Ana Silva",
+  "email": "ana@email.com",
+  "is_active": true,
+  "created_at": "2026-04-08T12:00:00Z",
+  "updated_at": "2026-04-08T12:00:00Z"
+}
+```
+
+### POST `/auth/login`
+
+Authenticates an existing user with email and password.
+
+Request body:
+
+```json
+{
+  "email": "ana@email.com",
+  "password": "12345678"
+}
+```
+
+Response `200 OK`:
+
+```json
+{
+  "access_token": "<token>",
+  "token_type": "bearer",
+  "user": {
+    "id": "550e8400-e29b-41d4-a716-446655440000",
+    "name": "Ana Silva",
+    "email": "ana@email.com",
+    "is_active": true,
+    "created_at": "2026-04-08T12:00:00Z",
+    "updated_at": "2026-04-08T12:00:00Z"
+  }
+}
+```
+
+### GET `/auth/me`
+
+Returns the authenticated user associated with the bearer token.
+
+Header:
+
+```text
+Authorization: Bearer <token>
+```

--- a/docs/setup/database-schema.md
+++ b/docs/setup/database-schema.md
@@ -8,6 +8,15 @@
 
 ```mermaid
 erDiagram
+    USERS {
+        UUID id PK
+        VARCHAR(255) name
+        VARCHAR(255) email
+        VARCHAR(255) password_hash
+        BOOLEAN is_active
+        TIMESTAMPTZ created_at
+        TIMESTAMPTZ updated_at
+    }
     VENUES {
         UUID id PK
         VARCHAR(255) name
@@ -31,6 +40,22 @@ erDiagram
 - Pydantic schemas expose `latitude`/`longitude` instead of raw PostGIS types (see [ADR-001](../adr/adr-001-orm-choice.md)).
 
 ## Tables
+
+### users
+
+Represents registered platform users and provides the base for authentication.
+
+| Column | Type | Nullable | Purpose | User Story |
+|--------|------|----------|---------|------------|
+| `id` | UUID | PK | Unique identifier | US1 |
+| `name` | VARCHAR(255) | No | User display name | US1 |
+| `email` | VARCHAR(255) | No | Login identifier | US1 |
+| `password_hash` | VARCHAR(255) | No | Hashed password for authentication | US1 |
+| `is_active` | BOOLEAN | No | Soft activation flag for auth checks | US1 |
+| `created_at` | TIMESTAMPTZ | No | Row creation time (server default) | — |
+| `updated_at` | TIMESTAMPTZ | No | Last update time (auto-updated) | — |
+
+Unique constraint: `email`.
 
 ### venues
 


### PR DESCRIPTION
## Description
Add the initial user authentication foundation for KULTI, including the `users` database model, Alembic migration, auth schemas, security helpers, service layer, auth routes, FastAPI app entrypoint, and supporting documentation. This creates the base needed for the next frontend and backend steps around user registration and login.

## Related User Story
US #1 - Create an account to save activities and preferences

## Changes
- Add `User` SQLAlchemy model and register it in `backend/app/models/__init__.py`
- Add user auth schemas for register, login, public user read, and token response
- Add auth security helpers for password hashing and bearer token generation/validation
- Add authentication service layer for user creation and login logic
- Add `/auth/register`, `/auth/login`, and `/auth/me` routes
- Add `backend/app/main.py` as the FastAPI app entrypoint
- Add Alembic migration to create the `users` table
- Update `docs/setup/database-schema.md` with the `users` table
- Add `docs/setup/auth-api.md` with request/response examples
- Update `docs/INDEX.md` and `docs/ASSISTANT.md` to reference the new auth documentation

## How to test

## Rollback plan
- [ ] Safe to revert (no migrations or data changes)
- [ ] Requires manual intervention (describe below)
- [x] Database migration needs rollback
- [ ] Environment variables or config changes need reverting

Rollback details:
Run `alembic downgrade 4bcd32a2d970` to remove the `users` table and return the database to the previous revision.

## Screenshots (if applicable)
N/A

## Checklist
- [ ] Branch follows naming convention (`feature/`, `fix/`, `refactor/`, `docs/`, `chore/`)
- [x] Code follows project standards
- [x] Tested locally
- [x] No errors in console/terminal
- [x] Documentation updated (if needed)
