### PR TITLE
feat: Add venue listing API endpoint #1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
 POSTGRES_USER=kulti
 POSTGRES_PASSWORD=kulti
 POSTGRES_DB=kulti
+
+# Frontend — Mapbox
+VITE_MAPBOX_TOKEN=your_mapbox_public_token

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -1,3 +1,4 @@
 from app.api.auth import router as auth_router
+from app.api.venues import router as venues_router
 
-__all__ = ["auth_router"]
+__all__ = ["auth_router", "venues_router"]

--- a/backend/app/api/venues.py
+++ b/backend/app/api/venues.py
@@ -1,0 +1,13 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.core.database import get_db
+from app.schemas import VenueRead
+from app.services import venue as venue_service
+
+router = APIRouter(prefix="/venues", tags=["venues"])
+
+
+@router.get("", response_model=list[VenueRead])
+def list_venues(db: Session = Depends(get_db)) -> list[VenueRead]:
+    return venue_service.list_venues(db)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,9 +1,11 @@
 from fastapi import FastAPI
 
 from app.api.auth import router as auth_router
+from app.api.venues import router as venues_router
 
 app = FastAPI(title="KULTI API")
 app.include_router(auth_router)
+app.include_router(venues_router)
 
 
 @app.get("/health", tags=["health"])

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,3 +1,3 @@
-from app.services import auth
+from app.services import auth, venue
 
-__all__ = ["auth"]
+__all__ = ["auth", "venue"]

--- a/backend/app/services/venue.py
+++ b/backend/app/services/venue.py
@@ -1,0 +1,35 @@
+from geoalchemy2.functions import ST_X, ST_Y
+from sqlalchemy import cast, select
+from sqlalchemy.orm import Session
+
+from geoalchemy2 import Geometry
+
+from app.models import Venue
+from app.schemas import VenueRead
+
+
+def list_venues(db: Session) -> list[VenueRead]:
+    geom = cast(Venue.location, Geometry)
+    stmt = select(
+        Venue,
+        ST_X(geom).label("longitude"),
+        ST_Y(geom).label("latitude"),
+    )
+    rows = db.execute(stmt).all()
+    return [
+        VenueRead(
+            id=venue.id,
+            name=venue.name,
+            description=venue.description,
+            category=venue.category,
+            address=venue.address,
+            latitude=latitude,
+            longitude=longitude,
+            phone=venue.phone,
+            website=venue.website,
+            image_url=venue.image_url,
+            created_at=venue.created_at,
+            updated_at=venue.updated_at,
+        )
+        for venue, longitude, latitude in rows
+    ]

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+.env

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -7,6 +7,7 @@ export default defineConfig({
   server: {
     proxy: {
       "/auth": "http://localhost:8000",
+      "/venues": "http://localhost:8000",
     },
   },
 });


### PR DESCRIPTION
### Description
Adds the backend endpoint for listing all venues with their coordinates extracted from PostGIS geography columns.

### Related User Story
US #2 - View museums on the map

### Changes
- Add `GET /venues` endpoint returning all venues with lat/lng (`backend/app/api/venues.py`)
- Add venue service with `ST_X`/`ST_Y` coordinate extraction via geometry cast (`backend/app/services/venue.py`)
- Register venue router in `main.py` and `api/__init__.py`
- Register venue service in `services/__init__.py`
- Add `/venues` proxy to Vite dev server config
- Add `.env` to frontend `.gitignore`
- Add `VITE_MAPBOX_TOKEN` to `.env.example`

### How to test
1. Start the backend: `cd backend && source venv/bin/activate && uvicorn app.main:app`
2. `curl http://localhost:8000/venues` — should return JSON array of venues with `latitude`/`longitude` fields
3. Verify the frontend proxy: `cd frontend && npm run dev`, then `curl http://localhost:5173/venues`

### Rollback plan
- [x] Safe to revert (no migrations or data changes)

### Checklist
- [x] Branch follows naming convention
- [x] Code follows project standards
- [x] Tested locally
- [x] No errors in console/terminal
- [ ] Documentation updated (if needed)