### PR TITLE
Add start.sh to launch full project

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ KULTI é uma plataforma web criada para admiradores de arte e turistas que veem 
 
 A documentação do projeto está disponível em [docs/INDEX.md](docs/INDEX.md) (em inglês).
 
+## Como Executar
+
+Após a configuração inicial ([SETUP.md](SETUP.md)), inicie todo o projeto com:
+
+```bash
+./start.sh
+```
+
+Isso sobe o banco de dados, o backend e o frontend em um único comando. Use `Ctrl+C` para encerrar todos os serviços.
+
 ## User Stories (MVP)
 1. Como visitante da plataforma, quero criar uma conta para salvar minhas atividades e preferências.
 2. Como usuário da plataforma, quero visualizar no mapa museus e galerias próximos para descobrir locais de interesse.

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e
+
+trap 'kill 0' EXIT
+
+echo "Starting database..."
+docker compose up -d
+
+echo "Starting backend..."
+(cd backend && source venv/bin/activate && uvicorn app.main:app --reload) &
+
+echo "Starting frontend..."
+(cd frontend && npm run dev) &
+
+wait


### PR DESCRIPTION
## Description
Add `start.sh` script to launch the database, backend, and frontend with a single command, and document it in the README.

## Changes
- Add `start.sh` that starts Docker DB, FastAPI backend, and Vite frontend in parallel
- Add "Como Executar" section to `README.md` pointing to the new script

## How to test
1. Run `./start.sh` from the project root
2. Verify the database container, backend (http://localhost:8000), and frontend (http://localhost:5173) are all running
3. Press `Ctrl+C` and verify all processes stop

## Rollback plan
- [x] Safe to revert (no migrations or data changes)

## Checklist
- [x] Branch follows naming convention (`feature/`, `fix/`, `refactor/`, `docs/`, `chore/`)
- [x] Code follows project standards
- [x] Tested locally
- [x] No errors in console/terminal
- [x] Documentation updated (if needed)
