### PR TITLE
Feature/record routes

### DIFF
--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -1,3 +1,3 @@
 from app.api.auth import router as auth_router
 
-__all__ = ["auth_router"]
+__all__ = ["auth_router", "records_router"]

--- a/backend/app/api/record.py
+++ b/backend/app/api/record.py
@@ -1,0 +1,109 @@
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+from sqlalchemy.exc import IntegrityError
+
+from app.core.database import get_db
+from app.models import Record, User
+from app.schemas import RecordCreate, RecordRead, RecordUpdate
+from app.services import record as record_service
+from app.api.auth import get_current_user
+
+router = APIRouter(prefix="/records", tags=["records"])
+
+def check_record_owner(record: Record, user: User) -> None:
+    if record.user_id != user.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not allowed to access this record.",
+        )
+
+@router.post("/", response_model=RecordRead, status_code=status.HTTP_201_CREATED)
+def create_record(
+    record_in: RecordCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> RecordRead:
+    """
+    Create a new record (user visit).
+    """
+
+    try:
+        record = record_service.create_record(
+            db,
+            record_in,
+            user_id=current_user.id,  # 👈 sempre seguro
+        )
+    except IntegrityError:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Record already exists for this user and venue.",
+        )
+
+    return RecordRead.model_validate(record)
+
+@router.get("/", response_model=list[RecordRead])
+def list_records(
+    venue_id: uuid.UUID | None = None,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> list[RecordRead]:
+    """
+    List records for the current user, optionally filtered by venue.
+    """
+
+    records = record_service.get_records(
+        db,
+        user_id=current_user.id,
+        venue_id=venue_id,
+    )
+
+    return [RecordRead.model_validate(r) for r in records]
+
+@router.get("/{record_id}", response_model=RecordRead)
+def get_record(
+    record_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> RecordRead:
+    """
+    Get a single record by ID.
+    """
+
+    record = record_service.get_record_by_id(db, record_id)
+
+    if record is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Record not found.",
+        )
+
+    check_record_owner(record, current_user)
+
+    return RecordRead.model_validate(record)
+
+@router.put("/{record_id}", response_model=RecordRead)
+def update_record(
+    record_id: uuid.UUID,
+    record_in: RecordUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> RecordRead:
+    """
+    Update a record.
+    """
+
+    record = record_service.get_record_by_id(db, record_id)
+
+    if record is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Record not found.",
+        )
+
+    check_record_owner(record, current_user)
+
+    record = record_service.update_record(db, record, record_in)
+
+    return RecordRead.model_validate(record)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,9 +1,11 @@
 from fastapi import FastAPI
 
 from app.api.auth import router as auth_router
+from app.api.record import router as record_router
 
 app = FastAPI(title="KULTI API")
 app.include_router(auth_router)
+app.include_router(record_router)
 
 
 @app.get("/health", tags=["health"])

--- a/backend/app/schemas/record.py
+++ b/backend/app/schemas/record.py
@@ -5,7 +5,6 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class RecordCreate(BaseModel):
-    user_id: uuid.UUID
     venue_id: uuid.UUID
     rating: int = Field(ge=1, le=5, description="Rating from 1 to 5 stars")
     comment: str | None = Field(None, max_length=1000)

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,3 +1,3 @@
 from app.services import auth
 
-__all__ = ["auth"]
+__all__ = ["auth", "record"]

--- a/backend/app/services/record.py
+++ b/backend/app/services/record.py
@@ -1,0 +1,63 @@
+import uuid
+from sqlalchemy.orm import Session
+from app.models import Record
+from app.schemas import RecordCreate, RecordUpdate
+
+
+def create_record(
+    db: Session,
+    record_in: RecordCreate,
+    user_id: uuid.UUID,
+) -> Record:
+    """Create a new record."""
+
+    record = Record(
+        **record_in.model_dump(),
+        user_id=user_id, 
+    )
+
+    db.add(record)
+    db.commit()
+    db.refresh(record)
+
+    return record
+
+
+def get_record_by_id(db: Session, record_id: uuid.UUID) -> Record | None:
+    """Fetch a single record by ID."""
+    return db.query(Record).filter(Record.id == record_id).first()
+
+
+def get_records(
+    db: Session,
+    user_id: uuid.UUID,
+    venue_id: uuid.UUID | None = None,
+) -> list[Record]:
+    """
+    Fetch records filtered by user (always) and optionally by venue.
+    """
+
+    query = db.query(Record).filter(Record.user_id == user_id)
+
+    if venue_id:
+        query = query.filter(Record.venue_id == venue_id)
+
+    return query.all()
+
+
+def update_record(
+    db: Session,
+    record: Record,
+    record_in: RecordUpdate,
+) -> Record:
+    """Update an existing record."""
+
+    update_data = record_in.model_dump(exclude_unset=True)
+
+    for field, value in update_data.items():
+        setattr(record, field, value)
+
+    db.commit()
+    db.refresh(record)
+
+    return record


### PR DESCRIPTION
<!-- PR title must match branch type: docs: , feat: , fix: , refactor: , chore: -->

## Description
Add records (user visits and ratings) API with secure CRUD operations. This PR implements creation, listing, retrieval, and update of records while enforcing proper authentication and authorization. It ensures that records are always associated with the authenticated user. 

## Related User Story
US #6  - Como usuário da plataforma, quero registrar que visitei um local para manter um histórico das minhas visitas culturais (passaporte digital).

## Changes
- `backend/app/services/record.py`:
  - Enforced filtering by authenticated user in `get_records`
  - Improved update logic with partial updates

- `backend/app/api/record.py`:
  - Implemented endpoints:
    - `POST /records/` → create record
    - `GET /records/` → list user records (optional filter by venue)
    - `GET /records/{id}` → get record by ID
    - `PUT /records/{id}` → update record
  - Added authorization checks to ensure users only access their own records
  - Added helper function to centralize ownership validation
  - Improved error handling using `IntegrityError` for unique constraint violations

- `backend/app/schemas/record.py`:
  - Removed `user_id` from `RecordCreate`
  - Ensured validation rules for rating and optional fields

- Security:
  - Prevents users from creating or accessing records of other users
  - Eliminates trust in client-provided identifiers

## How to test
1. Start the backend:
   ```bash
   uvicorn app.main:app --reload

## Rollback plan
<!-- What should be done if this PR causes issues in production? -->
- [X] Safe to revert (no migrations or data changes)
- [ ] Requires manual intervention (describe below)
- [ ] Database migration needs rollback
- [ ] Environment variables or config changes need reverting

## Screenshots (if applicable)

## Checklist
- [x] Branch follows naming convention (`feature/`, `fix/`, `refactor/`, `docs/`, `chore/`)
- [x] Code follows project standards
- [x] Tested locally
- [x] No errors in console/terminal
- [x] Documentation updated (if needed)
