### PR TITLE
fix: move VITE_MAPBOX_TOKEN to frontend/.env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,3 @@
 POSTGRES_USER=kulti
 POSTGRES_PASSWORD=kulti
 POSTGRES_DB=kulti
-
-# Frontend — Mapbox
-VITE_MAPBOX_TOKEN=your_mapbox_public_token

--- a/.env.example
+++ b/.env.example
@@ -2,5 +2,4 @@ POSTGRES_USER=kulti
 POSTGRES_PASSWORD=kulti
 POSTGRES_DB=kulti
 
-# Backend — Gemini AI
 GEMINI_API_KEY=your_gemini_api_key

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_MAPBOX_TOKEN=your_mapbox_public_token


### PR DESCRIPTION
## Description
Move `VITE_MAPBOX_TOKEN` from the root `.env.example` to `frontend/.env.example`, since Vite only reads env vars from the frontend directory. The root `.env.example` now only contains backend/infra variables (Postgres + Gemini API key).

## Related User Story
N/A — Developer experience fix

## Changes
- Moved `VITE_MAPBOX_TOKEN` to `frontend/.env.example`
- Kept `GEMINI_API_KEY` in root `.env.example` (added by main during merge)
- Cleaned up comments in root `.env.example`

## How to test
1. Clone the branch and copy `.env.example` to `.env` and `frontend/.env.example` to `frontend/.env`
2. Fill in the values and run `./start.sh`
3. Verify the map loads (Mapbox token works from frontend env) and AI features work (Gemini key works from root env)

## Rollback plan
- [x] Safe to revert (no migrations or data changes)
- [ ] Requires manual intervention (describe below)
- [ ] Database migration needs rollback
- [ ] Environment variables or config changes need reverting

## Screenshots (if applicable)
N/A

## Checklist
- [x] Branch follows naming convention (`feature/`, `fix/`, `refactor/`, `docs/`, `chore/`)
- [x] Code follows project standards
- [x] Tested locally
- [x] No errors in console/terminal
- [x] Documentation updated (if needed)