### PR TITLE
fix: add wishlists proxy to Vite dev server

### DIFF
--- a/frontend/src/components/map/venueDrawerContent.jsx
+++ b/frontend/src/components/map/venueDrawerContent.jsx
@@ -13,7 +13,7 @@ function InfoRow({ icon, text, href, onCopy }) {
   };
 
   return (
-    <div className="venue-info-row" onClick={handleRowClick}>
+    <div className={`venue-info-row${href ? " venue-info-row--link" : ""}`} onClick={handleRowClick}>
       <span className="venue-info-icon">{icon}</span>
       <span className="venue-info-text">{text}</span>
       <span className="venue-info-actions">

--- a/frontend/src/pages/mapPage.jsx
+++ b/frontend/src/pages/mapPage.jsx
@@ -15,8 +15,8 @@ const MAPBOX_TOKEN = import.meta.env.VITE_MAPBOX_TOKEN;
 const INITIAL_VIEW = { longitude: -43.9378, latitude: -19.9191, zoom: 12 };
 
 const MAX_BOUNDS = [
-  [-44.23, -20.14],
-  [-43.90, -19.84],
+  [-44.30, -20.14],
+  [-43.72, -19.84],
 ];
 
 // Drawer width (33.33vw) + left margin (1rem) + gap

--- a/frontend/src/styles/mapOverlay.css
+++ b/frontend/src/styles/mapOverlay.css
@@ -463,6 +463,10 @@
   color: var(--color-text-obsidian);
 }
 
+.venue-info-row--link:hover .venue-info-text {
+  text-decoration: underline;
+}
+
 .venue-info-icon {
   color: var(--color-text-charcoal);
   flex-shrink: 0;

--- a/frontend/src/styles/mapOverlay.css
+++ b/frontend/src/styles/mapOverlay.css
@@ -288,7 +288,7 @@
 }
 
 .venue-rating-star {
-  color: var(--color-text-obsidian);
+  color: #f5b50a;
 }
 
 .venue-rating-count {

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -8,7 +8,8 @@ export default defineConfig({
     proxy: {
       "/auth": "http://localhost:8000",
       "/venues": "http://localhost:8000",
-      "/records": "http://localhost:8000"
+      "/records": "http://localhost:8000",
+      "/wishlists": "http://localhost:8000"
     },
   },
 });


### PR DESCRIPTION
<!-- PR title must match branch type: docs: , feat: , fix: , refactor: , chore: -->

## Description
Collection of quick fixes for the map page and venue drawer.

## Related User Story
US #8 - Add venues to a wishlist
US #2 - View museums on the map

## Changes
- Added `/wishlists` proxy rule to `frontend/vite.config.js` — without it, all wishlist API calls were served by Vite as frontend routes instead of reaching the backend
- Changed venue rating stars color from black to yellow in the drawer
- Widened map `maxBounds` east limit to shift the default view left, giving more room for the side drawer
- Added underline on hover for the website link in the venue detail drawer

## How to test
1. Start backend and frontend with `./start.sh`
2. Log in and open the map — verify the default position feels centered with the drawer area in mind
3. Click a venue marker — verify the stars in the drawer are yellow
4. Click the heart icon — it should toggle and persist across page reloads
5. Hover over the website row in the venue drawer — text should underline

## Rollback plan
- [x] Safe to revert (no migrations or data changes)
- [ ] Requires manual intervention (describe below)
- [ ] Database migration needs rollback
- [ ] Environment variables or config changes need reverting

## Screenshots (if applicable)
N/A

## Checklist
- [x] Branch follows naming convention (`feature/`, `fix/`, `refactor/`, `docs/`, `chore/`)
- [x] Code follows project standards
- [x] Tested locally
- [x] No errors in console/terminal
- [x] Documentation updated (if needed)