### PR TITLE
  feat: add AI-powered route recommendations to passport

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,13 @@
 POSTGRES_USER=kulti
 POSTGRES_PASSWORD=kulti
 POSTGRES_DB=kulti
+DATABASE_URL=postgresql://user:password@localhost:5432/mydb?schema=public
 
 # Backend — Auth
 ACCESS_TOKEN_EXPIRE_MINUTES=1440
+AUTH_SECRET_KEY=change_this_in_production
 
 # Backend — Gemini AI
 GEMINI_API_KEY=your_gemini_api_key
+
+

--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@ DATABASE_URL=postgresql://user:password@localhost:5432/mydb?schema=public
 
 # Backend — Auth
 ACCESS_TOKEN_EXPIRE_MINUTES=1440
-AUTH_SECRET_KEY=change_this_in_production
+AUTH_SECRET_KEY=a_long_random_string
 
 # Backend — Gemini AI
 GEMINI_API_KEY=your_gemini_api_key

--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@ POSTGRES_PASSWORD=kulti
 POSTGRES_DB=kulti
 
 # Backend — Auth
-ACCESS_TOKEN_EXPIRE_MINUTES=480
+ACCESS_TOKEN_EXPIRE_MINUTES=1440
 
 # Backend — Gemini AI
 GEMINI_API_KEY=your_gemini_api_key

--- a/.env.example
+++ b/.env.example
@@ -1,13 +1,12 @@
-POSTGRES_USER=kulti
-POSTGRES_PASSWORD=kulti
-POSTGRES_DB=kulti
-DATABASE_URL=postgresql://user:password@localhost:5432/mydb?schema=public
+POSTGRES_USER=your_postgres_user
+POSTGRES_PASSWORD=your_postgres_password
+POSTGRES_DB=your_postgres_db
+DATABASE_URL=postgresql+psycopg://user:password@localhost:5432/dbname
 
 # Backend — Auth
 ACCESS_TOKEN_EXPIRE_MINUTES=1440
-AUTH_SECRET_KEY=a_long_random_string
+AUTH_SECRET_KEY=your_secret_key
 
 # Backend — Gemini AI
 GEMINI_API_KEY=your_gemini_api_key
-
-
+GEMINI_MODEL=gemini-1.5-flash

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -1,6 +1,13 @@
 from app.api.auth import router as auth_router
-from app.api.venue import router as venue_router
+from app.api.recommendation import router as recommendation_router
 from app.api.record import router as record_router
+from app.api.venue import router as venue_router
 from app.api.wishlist import router as wishlist_router
 
-__all__ = ["auth_router", "venue_router", "record_router", "wishlist_router"]
+__all__ = [
+    "auth_router",
+    "recommendation_router",
+    "record_router",
+    "venue_router",
+    "wishlist_router",
+]

--- a/backend/app/api/recommendation.py
+++ b/backend/app/api/recommendation.py
@@ -1,0 +1,18 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.api.auth import get_current_user
+from app.core.database import get_db
+from app.models import User
+from app.schemas import RecommendationRead
+from app.services import recommendation as recommendation_service
+
+router = APIRouter(prefix="/recommendations", tags=["recommendations"])
+
+
+@router.get("", response_model=RecommendationRead)
+def get_recommendations(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> RecommendationRead:
+    return recommendation_service.get_recommendations(db, current_user.id)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -6,6 +6,8 @@ ROOT_DIR = Path(__file__).resolve().parents[3]
 
 
 class Settings(BaseSettings):
+    AUTH_SECRET_KEY: str = ""
+    ACCESS_TOKEN_EXPIRE_MINUTES: int = 1440
     PROJECT_NAME: str = "KULTI"
     GEMINI_API_KEY: str = ""
     GEMINI_MODEL: str = "gemini-1.5-flash"

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,17 +1,20 @@
+from pathlib import Path
+
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-class Settings(BaseSettings):
-    # App Settings
-    PROJECT_NAME: str = "KULTI"
-    
-    # AI Settings
-    GEMINI_API_KEY: str
-    
-    # Database Settings
-    POSTGRES_USER: str
-    POSTGRES_PASSWORD: str
-    POSTGRES_DB: str
+ROOT_DIR = Path(__file__).resolve().parents[3]
 
-    model_config = SettingsConfigDict(env_file="../.env", extra="ignore")
+
+class Settings(BaseSettings):
+    PROJECT_NAME: str = "KULTI"
+    GEMINI_API_KEY: str = ""
+    GEMINI_MODEL: str = "gemini-1.5-flash"
+    DATABASE_URL: str = "postgresql+psycopg://kulti:kulti@localhost:5432/kulti"
+    POSTGRES_USER: str = "kulti"
+    POSTGRES_PASSWORD: str = "kulti"
+    POSTGRES_DB: str = "kulti"
+
+    model_config = SettingsConfigDict(env_file=ROOT_DIR / ".env", extra="ignore")
+
 
 settings = Settings()

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -6,17 +6,16 @@ ROOT_DIR = Path(__file__).resolve().parents[3]
 
 
 class Settings(BaseSettings):
-    AUTH_SECRET_KEY: str = ""
-    ACCESS_TOKEN_EXPIRE_MINUTES: int = 1440
+    AUTH_SECRET_KEY: str
+    ACCESS_TOKEN_EXPIRE_MINUTES: int
     PROJECT_NAME: str = "KULTI"
-    GEMINI_API_KEY: str = ""
-    GEMINI_MODEL: str = "gemini-1.5-flash"
-    DATABASE_URL: str = "postgresql+psycopg://kulti:kulti@localhost:5432/kulti"
-    POSTGRES_USER: str = "kulti"
-    POSTGRES_PASSWORD: str = "kulti"
-    POSTGRES_DB: str = "kulti"
+    GEMINI_API_KEY: str
+    GEMINI_MODEL: str
+    DATABASE_URL: str
+    POSTGRES_USER: str
+    POSTGRES_PASSWORD: str
+    POSTGRES_DB: str
 
     model_config = SettingsConfigDict(env_file=ROOT_DIR / ".env", extra="ignore")
-
 
 settings = Settings()

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -1,14 +1,10 @@
-import os
-
 from sqlalchemy import create_engine
 from sqlalchemy.orm import DeclarativeBase, sessionmaker
 
-DATABASE_URL = os.getenv(
-    "DATABASE_URL",
-    "postgresql+psycopg://kulti:kulti@localhost:5432/kulti",
-)
+from app.core.config import settings
 
-engine = create_engine(DATABASE_URL)
+
+engine = create_engine(settings.DATABASE_URL)
 SessionLocal = sessionmaker(bind=engine)
 
 

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -5,9 +5,14 @@ import json
 import os
 import secrets
 import time
+from app.core.config import settings
 
-SECRET_KEY = os.getenv("AUTH_SECRET_KEY", "change-me-in-production")
-ACCESS_TOKEN_EXPIRE_MINUTES = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "60"))
+
+if not settings.AUTH_SECRET_KEY:
+  raise RuntimeError("AUTH_SECRET_KEY must be set in the environment.")
+    
+SECRET_KEY = settings.AUTH_SECRET_KEY
+ACCESS_TOKEN_EXPIRE_MINUTES = settings.ACCESS_TOKEN_EXPIRE_MINUTES
 PASSWORD_HASH_ITERATIONS = 100_000
 
 def _urlsafe_b64encode(data: bytes) -> str:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,14 +1,16 @@
 from fastapi import FastAPI
 
 from app.api.auth import router as auth_router
-from app.api.venue import router as venue_router
+from app.api.recommendation import router as recommendation_router
 from app.api.record import router as record_router
+from app.api.venue import router as venue_router
 from app.api.wishlist import router as wishlist_router
 
 app = FastAPI(title="KULTI API")
 app.include_router(auth_router)
-app.include_router(venue_router)
+app.include_router(recommendation_router)
 app.include_router(record_router)
+app.include_router(venue_router)
 app.include_router(wishlist_router)
 
 

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,4 +1,9 @@
 from app.schemas.record import RecordCreate, RecordRead, RecordUpdate
+from app.schemas.recommendation import (
+    RecommendationAiOutput,
+    RecommendationRead,
+    RecommendationVenueRead,
+)
 from app.schemas.user import AuthTokenRead, UserCreate, UserLogin, UserRead
 from app.schemas.venue import (
     VenueCreate,
@@ -11,6 +16,9 @@ from app.schemas.wishlist import WishlistCreate, WishlistRead
 
 __all__ = [
     "AuthTokenRead",
+    "RecommendationAiOutput",
+    "RecommendationRead",
+    "RecommendationVenueRead",
     "RecordCreate",
     "RecordRead",
     "RecordUpdate",

--- a/backend/app/schemas/recommendation.py
+++ b/backend/app/schemas/recommendation.py
@@ -1,0 +1,31 @@
+import uuid
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class RecommendationAiOutput(BaseModel):
+    itinerary_title: str = Field(min_length=1)
+    itinerary_names: list[str] = Field(min_length=3, max_length=3)
+    curator_note: str = Field(min_length=1)
+    interpretability_logic: dict[str, str]
+
+
+class RecommendationVenueRead(BaseModel):
+    id: uuid.UUID
+    name: str
+    description: str | None
+    category: str
+    address: str
+    latitude: float
+    longitude: float
+    image_url: str | None
+    justification: str
+
+
+class RecommendationRead(BaseModel):
+    itinerary_title: str
+    curator_note: str
+    source: Literal["ai", "popularity_fallback", "no_candidates"]
+    fallback_reason: str | None = None
+    venues: list[RecommendationVenueRead]

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,3 +1,3 @@
-from app.services import auth, venue, record, wishlist
+from app.services import auth, recommendation, record, venue, wishlist
 
-__all__ = ["auth", "venue", "record", "wishlist"]
+__all__ = ["auth", "recommendation", "record", "venue", "wishlist"]

--- a/backend/app/services/recommendation.py
+++ b/backend/app/services/recommendation.py
@@ -1,0 +1,80 @@
+import json
+import uuid
+from collections import Counter
+from socket import timeout as SocketTimeout
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+from geoalchemy2 import Geometry
+from geoalchemy2.functions import ST_X, ST_Y
+from pydantic import ValidationError
+from sqlalchemy import cast, desc, func, select
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.models import Record, Venue, Wishlist
+from app.schemas import (
+    RecommendationAiOutput,
+    RecommendationRead,
+    RecommendationVenueRead,
+    VenueRead,
+)
+
+GEMINI_TIMEOUT_SECONDS = 12
+MAX_AI_CANDIDATES = 20
+RECOMMENDATION_SIZE = 3
+
+_geom = cast(Venue.location, Geometry)
+
+SYSTEM_INSTRUCTION = """
+You are the Personal Curator for KULTI, a specialized platform for art galleries
+and museums in Brazil. Design a cohesive 3-venue cultural itinerary using only
+the supplied venue dataset. Return only valid raw JSON, with all user-facing text
+in Brazilian Portuguese.
+""".strip()
+
+
+class RecommendationAiError(Exception):
+    pass
+
+
+def _venue_select():
+    return select(Venue, ST_X(_geom), ST_Y(_geom))
+
+
+def _to_venue_read(row) -> VenueRead:
+    venue, lon, lat = row
+    return VenueRead(
+        id=venue.id,
+        name=venue.name,
+        description=venue.description,
+        category=venue.category,
+        address=venue.address,
+        latitude=lat,
+        longitude=lon,
+        phone=venue.phone,
+        website=venue.website,
+        image_url=venue.image_url,
+        created_at=venue.created_at,
+        updated_at=venue.updated_at,
+    )
+
+
+def _load_record_venues(db: Session, user_id: uuid.UUID) -> list[VenueRead]:
+    stmt = (
+        _venue_select()
+        .join(Record, Record.venue_id == Venue.id)
+        .where(Record.user_id == user_id)
+    )
+    return [_to_venue_read(row) for row in db.execute(stmt).all()]
+
+
+def _load_wishlist_venues(db: Session, user_id: uuid.UUID) -> list[VenueRead]:
+    stmt = (
+        _venue_select()
+        .join(Wishlist, Wishlist.venue_id == Venue.id)
+        .where(Wishlist.user_id == user_id)
+    )
+    return [_to_venue_read(row) for row in db.execute(stmt).all()]
+

--- a/backend/app/services/recommendation.py
+++ b/backend/app/services/recommendation.py
@@ -238,3 +238,75 @@ def _call_gemini(prompt: str) -> RecommendationAiOutput:
         headers={"Content-Type": "application/json"},
         method="POST",
     )
+
+    try:
+        with urlopen(request, timeout=GEMINI_TIMEOUT_SECONDS) as response:
+            data = json.loads(response.read().decode("utf-8"))
+    except (HTTPError, URLError, SocketTimeout, TimeoutError, json.JSONDecodeError) as exc:
+        raise RecommendationAiError("Gemini request failed.") from exc
+
+    try:
+        raw_text = data["candidates"][0]["content"]["parts"][0]["text"]
+        return RecommendationAiOutput.model_validate_json(raw_text)
+    except (KeyError, IndexError, TypeError, ValidationError) as exc:
+        raise RecommendationAiError("Gemini returned invalid JSON.") from exc
+
+
+def _to_recommendation_venue(
+    venue: VenueRead,
+    justification: str,
+) -> RecommendationVenueRead:
+    return RecommendationVenueRead(
+        id=venue.id,
+        name=venue.name,
+        description=venue.description,
+        category=venue.category,
+        address=venue.address,
+        latitude=venue.latitude,
+        longitude=venue.longitude,
+        image_url=venue.image_url,
+        justification=justification,
+    )
+
+
+def _build_ai_recommendation(
+    ai_output: RecommendationAiOutput,
+    candidates: list[VenueRead],
+) -> RecommendationRead:
+    candidates_by_name = {venue.name: venue for venue in candidates}
+    recommended: list[RecommendationVenueRead] = []
+    seen_names: set[str] = set()
+
+    for index, name in enumerate(ai_output.itinerary_names, start=1):
+        venue = candidates_by_name.get(name)
+        if venue is None or name in seen_names:
+            continue
+        seen_names.add(name)
+        justification = ai_output.interpretability_logic.get(
+            f"venue_{index}_choice",
+            "Selecionado por coerência com o roteiro recomendado.",
+        )
+        recommended.append(_to_recommendation_venue(venue, justification))
+
+    if len(recommended) != RECOMMENDATION_SIZE:
+        raise RecommendationAiError("Gemini selected venues outside the candidate pool.")
+
+    return RecommendationRead(
+        itinerary_title=ai_output.itinerary_title,
+        curator_note=ai_output.curator_note,
+        source="ai",
+        venues=recommended,
+    )
+
+
+def _no_candidates_response() -> RecommendationRead:
+    return RecommendationRead(
+        itinerary_title="Ainda não há recomendações disponíveis",
+        curator_note=(
+            "Não encontramos locais suficientes fora do seu histórico e da sua "
+            "lista de desejos para montar um roteiro agora."
+        ),
+        source="no_candidates",
+        venues=[],
+    )
+

--- a/backend/app/services/recommendation.py
+++ b/backend/app/services/recommendation.py
@@ -78,3 +78,78 @@ def _load_wishlist_venues(db: Session, user_id: uuid.UUID) -> list[VenueRead]:
     )
     return [_to_venue_read(row) for row in db.execute(stmt).all()]
 
+
+def _preferred_categories(
+    record_venues: list[VenueRead],
+    wishlist_venues: list[VenueRead],
+) -> list[str]:
+    counts = Counter(
+        venue.category
+        for venue in [*record_venues, *wishlist_venues]
+        if venue.category
+    )
+    return [category for category, _count in counts.most_common()]
+
+
+def _exclude_blocked(stmt, blocked_ids: set[uuid.UUID]):
+    if not blocked_ids:
+        return stmt
+    return stmt.where(Venue.id.notin_(blocked_ids))
+
+
+def _load_candidate_venues(
+    db: Session,
+    blocked_ids: set[uuid.UUID],
+    categories: list[str],
+    limit: int = MAX_AI_CANDIDATES,
+) -> list[VenueRead]:
+    stmt = _exclude_blocked(_venue_select(), blocked_ids)
+    if categories:
+        stmt = stmt.where(Venue.category.in_(categories))
+    stmt = stmt.order_by(Venue.name).limit(limit)
+    return [_to_venue_read(row) for row in db.execute(stmt).all()]
+
+
+def _load_popular_venues(
+    db: Session,
+    blocked_ids: set[uuid.UUID],
+    limit: int = RECOMMENDATION_SIZE,
+) -> list[VenueRead]:
+    popularity = (
+        select(
+            Record.venue_id.label("venue_id"),
+            func.count(Record.id).label("visit_count"),
+        )
+        .group_by(Record.venue_id)
+        .subquery()
+    )
+    stmt = (
+        _venue_select()
+        .join(popularity, popularity.c.venue_id == Venue.id)
+        .order_by(desc(popularity.c.visit_count), Venue.name)
+        .limit(limit)
+    )
+    stmt = _exclude_blocked(stmt, blocked_ids)
+    return [_to_venue_read(row) for row in db.execute(stmt).all()]
+
+
+def _load_available_venues(
+    db: Session,
+    blocked_ids: set[uuid.UUID],
+    limit: int,
+) -> list[VenueRead]:
+    stmt = _exclude_blocked(_venue_select(), blocked_ids)
+    stmt = stmt.order_by(Venue.name).limit(limit)
+    return [_to_venue_read(row) for row in db.execute(stmt).all()]
+
+
+def _candidate_payload(venues: list[VenueRead]) -> list[dict[str, str | None]]:
+    return [
+        {
+            "name": venue.name,
+            "category": venue.category,
+            "description": venue.description,
+        }
+        for venue in venues
+    ]
+

--- a/backend/app/services/recommendation.py
+++ b/backend/app/services/recommendation.py
@@ -310,3 +310,71 @@ def _no_candidates_response() -> RecommendationRead:
         venues=[],
     )
 
+
+def _build_popularity_fallback(
+    db: Session,
+    blocked_ids: set[uuid.UUID],
+    reason: str,
+) -> RecommendationRead:
+    venues = _load_popular_venues(db, blocked_ids, RECOMMENDATION_SIZE)
+    if len(venues) < RECOMMENDATION_SIZE:
+        existing_ids = {venue.id for venue in venues}
+        fill_venues = _load_available_venues(
+            db,
+            blocked_ids | existing_ids,
+            RECOMMENDATION_SIZE - len(venues),
+        )
+        venues.extend(fill_venues)
+
+    if not venues:
+        return _no_candidates_response()
+
+    recommendations = [
+        _to_recommendation_venue(
+            venue,
+            "Este local aparece como uma opção relevante entre os espaços disponíveis.",
+        )
+        for venue in venues[:RECOMMENDATION_SIZE]
+    ]
+    return RecommendationRead(
+        itinerary_title="Roteiro em destaque",
+        curator_note=(
+            "Selecionamos locais com bom sinal de interesse da comunidade para "
+            "manter seu passaporte em movimento."
+        ),
+        source="popularity_fallback",
+        fallback_reason=reason,
+        venues=recommendations,
+    )
+
+
+def get_recommendations(db: Session, user_id: uuid.UUID) -> RecommendationRead:
+    record_venues = _load_record_venues(db, user_id)
+    wishlist_venues = _load_wishlist_venues(db, user_id)
+    blocked_ids = {venue.id for venue in [*record_venues, *wishlist_venues]}
+    categories = _preferred_categories(record_venues, wishlist_venues)
+
+    if not record_venues and not wishlist_venues:
+        return _build_popularity_fallback(
+            db,
+            blocked_ids,
+            "Usamos popularidade porque seu passaporte ainda não tem histórico.",
+        )
+
+    candidates = _load_candidate_venues(db, blocked_ids, categories)
+    if len(candidates) < RECOMMENDATION_SIZE:
+        candidates = _load_candidate_venues(db, blocked_ids, [])
+
+    if not candidates:
+        return _no_candidates_response()
+
+    try:
+        prompt = _build_prompt(record_venues, wishlist_venues, categories, candidates)
+        ai_output = _call_gemini(prompt)
+        return _build_ai_recommendation(ai_output, candidates)
+    except RecommendationAiError:
+        return _build_popularity_fallback(
+            db,
+            blocked_ids,
+            "Usamos popularidade porque a curadoria por IA não respondeu agora.",
+        )

--- a/backend/app/services/recommendation.py
+++ b/backend/app/services/recommendation.py
@@ -153,3 +153,88 @@ def _candidate_payload(venues: list[VenueRead]) -> list[dict[str, str | None]]:
         for venue in venues
     ]
 
+
+def _context_payload(
+    record_venues: list[VenueRead],
+    wishlist_venues: list[VenueRead],
+    categories: list[str],
+) -> dict[str, list[dict[str, str]] | list[str]]:
+    return {
+        "visited_venues": [
+            {"name": venue.name, "category": venue.category}
+            for venue in record_venues
+        ],
+        "wishlist": [
+            {"name": venue.name, "category": venue.category}
+            for venue in wishlist_venues
+        ],
+        "preferences": categories,
+    }
+
+
+def _build_prompt(
+    record_venues: list[VenueRead],
+    wishlist_venues: list[VenueRead],
+    categories: list[str],
+    candidates: list[VenueRead],
+) -> str:
+    return f"""
+Analyze the following dataset and construct a curated itinerary.
+
+Data Source:
+- Origin: User History/Wishlist
+
+User Context:
+{json.dumps(_context_payload(record_venues, wishlist_venues, categories), ensure_ascii=False)}
+
+Available Candidate Pool:
+{json.dumps(_candidate_payload(candidates), ensure_ascii=False)}
+
+Objective:
+Select exactly 3 venues from the Available Candidate Pool that form a coherent
+and engaging thematic itinerary.
+
+Strict Constraints:
+1. Do NOT include venues already visited by the user.
+2. Do NOT include venues already in the user's wishlist.
+3. Venue names must match EXACTLY as provided, including case.
+4. Return ONLY valid raw JSON.
+5. All user-facing text must be in Brazilian Portuguese.
+6. Use this exact schema:
+{{
+  "itinerary_title": "Título criativo em pt-BR para o roteiro",
+  "itinerary_names": ["Exact Venue Name 1", "Exact Venue Name 2", "Exact Venue Name 3"],
+  "curator_note": "Explicação coesa em 1-2 frases em pt-BR",
+  "interpretability_logic": {{
+    "venue_1_choice": "Justificativa do primeiro local",
+    "venue_2_choice": "Justificativa do segundo local",
+    "venue_3_choice": "Justificativa do terceiro local"
+  }}
+}}
+""".strip()
+
+
+def _call_gemini(prompt: str) -> RecommendationAiOutput:
+    api_key = settings.GEMINI_API_KEY.strip()
+    if not api_key or api_key == "your_gemini_api_key":
+        raise RecommendationAiError("Gemini API key is not configured.")
+
+    model = quote(settings.GEMINI_MODEL, safe="")
+    url = (
+        "https://generativelanguage.googleapis.com/v1beta/models/"
+        f"{model}:generateContent?key={quote(api_key, safe='')}"
+    )
+    payload = {
+        "system_instruction": {"parts": [{"text": SYSTEM_INSTRUCTION}]},
+        "contents": [{"role": "user", "parts": [{"text": prompt}]}],
+        "generationConfig": {
+            "temperature": 0.4,
+            "response_mime_type": "application/json",
+        },
+    }
+    request = Request(
+        url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -29,4 +29,4 @@
 | [ai-tools-access.md](guidelines/ai-tools-access.md) | Recommended AI agents and mapping libraries access status |
 | [design-decisions.md](guidelines/design-decisions.md) | Visual identity, color palette (Celadon), typography, and UI component standards |
 | [ai-suggestions-behavior.md](guidelines/ai-suggestions-behavior.md) | Logic, sequence flow, and decision-making for the Gemini-powered recommendation system |
-| [ai-suggestions-prompts.md](guidelines/ai-itinerary-prompts.md) | Structured prompt templates and JSON output definitions for Gemini |
+| [ai-suggestions-prompts.md](guidelines/ai-suggestions-prompts.md) | Structured prompt templates and JSON output definitions for Gemini |

--- a/docs/setup/backend-setup.md
+++ b/docs/setup/backend-setup.md
@@ -7,6 +7,8 @@
 ## Prerequisites
 
 - [Python 3.12+](https://www.python.org/downloads/)
+- The backend reads configuration from the repository-root `.env` file.
+  Make sure `DATABASE_URL`, `AUTH_SECRET_KEY`, and `GEMINI_API_KEY` are set.
 
 ## Installation
 

--- a/frontend/src/components/passport/recommendationPanel.jsx
+++ b/frontend/src/components/passport/recommendationPanel.jsx
@@ -1,0 +1,94 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { CaretLeft, CaretRight, Heart } from "@phosphor-icons/react";
+import { addToWishlist, checkWishlistStatus, removeFromWishlist } from "../../services/wishlistService.js";
+
+function openVenue(venueId) {
+  window.location.href = `/map?venue=${venueId}`;
+}
+
+export function RecommendationPanel({ error, loading, recommendation }) {
+  const listRef = useRef(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+  const [wishlistedById, setWishlistedById] = useState({});
+
+  const updateArrows = useCallback(() => {
+    const el = listRef.current;
+    if (!el) return;
+
+    setCanScrollLeft(el.scrollLeft > 1);
+    setCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
+  }, []);
+
+  useEffect(() => {
+    updateArrows();
+
+    const el = listRef.current;
+    el?.addEventListener("scroll", updateArrows);
+    window.addEventListener("resize", updateArrows);
+
+    return () => {
+      el?.removeEventListener("scroll", updateArrows);
+      window.removeEventListener("resize", updateArrows);
+    };
+  }, [recommendation, updateArrows]);
+
+  useEffect(() => {
+    if (!recommendation) return;
+
+    Promise.all(
+      recommendation.venues.map((venue) =>
+        checkWishlistStatus(venue.id)
+          .then((res) => [venue.id, res.wishlisted])
+          .catch(() => [venue.id, false]),
+      ),
+    ).then((entries) => setWishlistedById(Object.fromEntries(entries)));
+  }, [recommendation]);
+
+  const scroll = useCallback((direction) => {
+    const el = listRef.current;
+    if (!el) return;
+
+    el.scrollBy({
+      left: direction * el.clientWidth,
+      behavior: "smooth",
+    });
+  }, []);
+
+  const toggleWishlist = useCallback((venueId) => {
+    const next = !wishlistedById[venueId];
+    setWishlistedById((current) => ({ ...current, [venueId]: next }));
+    (next ? addToWishlist(venueId) : removeFromWishlist(venueId)).catch(() => {
+      setWishlistedById((current) => ({ ...current, [venueId]: !next }));
+    });
+  }, [wishlistedById]);
+
+  if (loading) {
+    return (
+      <section className="recommendation-panel">
+        <p className="recommendation-status">Preparando recomendações...</p>
+      </section>
+    );
+  }
+
+  if (error) {
+    return (
+      <section className="recommendation-panel recommendation-panel--muted">
+        <h2 className="recommendation-title">Roteiro indisponível</h2>
+        <p className="recommendation-status">{error}</p>
+      </section>
+    );
+  }
+
+  if (!recommendation || recommendation.venues.length === 0) {
+    return (
+      <section className="recommendation-panel recommendation-panel--muted">
+        <h2 className="recommendation-title">
+          Ainda não há recomendações disponíveis
+        </h2>
+        <p className="recommendation-status">
+          Registre visitas ou adicione locais à sua lista para receber um roteiro.
+        </p>
+      </section>
+    );
+  }

--- a/frontend/src/components/passport/recommendationPanel.jsx
+++ b/frontend/src/components/passport/recommendationPanel.jsx
@@ -92,3 +92,100 @@ export function RecommendationPanel({ error, loading, recommendation }) {
       </section>
     );
   }
+
+  const usedFallback = recommendation.source === "popularity_fallback";
+  const isAi = recommendation.source === "ai";
+
+  return (
+    <section className="recommendation-panel">
+      <div className="recommendation-heading">
+        <div>
+          <span className="recommendation-kicker">Roteiro recomendado</span>
+          <h2 className="recommendation-title">
+            {recommendation.itinerary_title}
+          </h2>
+        </div>
+        {(usedFallback || isAi) && (
+          <span className={`recommendation-badge${isAi ? " recommendation-badge--ai" : ""}`}>
+            {isAi ? "Gerado por IA" : "Popularidade"}
+          </span>
+        )}
+      </div>
+
+      <p className="recommendation-note">{recommendation.curator_note}</p>
+
+      {usedFallback && recommendation.fallback_reason && (
+        <p className="recommendation-fallback">
+          {recommendation.fallback_reason}
+        </p>
+      )}
+
+      <div className="recommendation-carousel">
+        {canScrollLeft && (
+          <button
+            aria-label="Ver recomendação anterior"
+            className="carousel-arrow carousel-arrow--left recommendation-arrow"
+            onClick={() => scroll(-1)}
+            type="button"
+          >
+            <CaretLeft size={14} weight="bold" />
+          </button>
+        )}
+
+        <div className="recommendation-list" ref={listRef}>
+          {recommendation.venues.map((venue) => (
+            <div
+              className="recommendation-card"
+              key={venue.id}
+              onClick={() => openVenue(venue.id)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  openVenue(venue.id);
+                }
+              }}
+              role="button"
+              tabIndex={0}
+            >
+              <button
+                aria-label={wishlistedById[venue.id] ? "Remover da wishlist" : "Adicionar à wishlist"}
+                className={`venue-detail-wishlist${wishlistedById[venue.id] ? " active" : ""}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  toggleWishlist(venue.id);
+                }}
+                type="button"
+              >
+                <Heart size={20} weight={wishlistedById[venue.id] ? "fill" : "regular"} />
+              </button>
+              <img
+                alt={venue.name}
+                className="recommendation-image"
+                src={venue.image_url || "https://via.placeholder.com/400x220"}
+              />
+              <span className="recommendation-card-body">
+                <span className="recommendation-category">{venue.category}</span>
+                <span className="recommendation-name">{venue.name}</span>
+                <span className="recommendation-address">{venue.address}</span>
+                <span className="recommendation-justification">
+                  {venue.justification}
+                </span>
+              </span>
+            </div>
+          ))}
+        </div>
+
+        {canScrollRight && (
+          <button
+            aria-label="Ver próxima recomendação"
+            className="carousel-arrow carousel-arrow--right recommendation-arrow"
+            onClick={() => scroll(1)}
+            type="button"
+          >
+            <CaretRight size={14} weight="bold" />
+          </button>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/pages/loginPage.jsx
+++ b/frontend/src/pages/loginPage.jsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { AuthShell } from "../components/auth/authShell.jsx";
 import { LoginForm } from "../components/auth/loginForm.jsx";
 import { loginUser } from "../services/authService.js";
+import { primeRecommendationCache } from "../services/recommendationService.js";
 import { saveAccessToken } from "../services/tokenStorage.js";
 
 function loginRedirectPath() {
@@ -29,6 +30,9 @@ export default function LoginPage() {
     try {
       const auth = await loginUser(credentials);
       saveAccessToken(auth.access_token);
+      await primeRecommendationCache().catch((err) => {
+        console.error("Failed to prime recommendations:", err);
+      });
       setSuccess(`Bem-vindo de volta, ${auth.user.name}.`);
       window.location.replace(loginRedirectPath());
     } catch (requestError) {

--- a/frontend/src/pages/mapPage.jsx
+++ b/frontend/src/pages/mapPage.jsx
@@ -64,6 +64,8 @@ export default function MapPage() {
       category: activeCategory,
     }),
     [activeCategory, debouncedSearch],
+  );
+
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
     const venueId = params.get("venue");
@@ -257,13 +259,6 @@ export default function MapPage() {
     venueParamsKey,
     venues,
   ]);
-
-  const categorySource = allVenues.length > 0 ? allVenues : venues;
-
-  const categories = useMemo(
-    () => [...new Set(categorySource.map((v) => v.category))].sort(),
-    [categorySource],
-  );
 
   const searchResults = useMemo(() => {
     if (search.trim().length < 2) return [];

--- a/frontend/src/pages/passportPage.tsx
+++ b/frontend/src/pages/passportPage.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useState } from "react";
 
 import { fetchRecords } from "../services/recordService.js";
+import { fetchRecommendations } from "../services/recommendationService.js";
 import { fetchVenues } from "../services/venueService.js";
 import { listWishlist } from "../services/wishlistService.js";
 
 import { PassportHeader } from "../components/passport/passportHeader";
+import { RecommendationPanel } from "../components/passport/recommendationPanel.jsx";
 import { RecordList } from "../components/passport/recordList";
 import { WishlistList } from "../components/passport/wishlistList";
 import { KultiLogo } from "../components/brand/kultiLogo.jsx";
@@ -18,6 +20,24 @@ export default function PassportPage() {
   const [loading, setLoading] = useState(true);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [tab, setTab] = useState("records");
+  const [recommendation, setRecommendation] = useState(null);
+  const [recommendationError, setRecommendationError] = useState("");
+  const [recommendationLoading, setRecommendationLoading] = useState(true);
+
+  async function reloadRecommendations({ forceRefresh = false } = {}) {
+    setRecommendationLoading(true);
+    setRecommendationError("");
+
+    try {
+      const data = await fetchRecommendations({ forceRefresh });
+      setRecommendation(data);
+    } catch (err) {
+      setRecommendation(null);
+      setRecommendationError("Não foi possível carregar seu roteiro agora.");
+    } finally {
+      setRecommendationLoading(false);
+    }
+  }
 
   async function reloadRecords() {
     const data = await fetchRecords();
@@ -49,6 +69,7 @@ export default function PassportPage() {
     }
 
     loadData();
+    reloadRecommendations();
   }, []);
 
   return (
@@ -87,6 +108,12 @@ export default function PassportPage() {
         </div>
 
         <PassportHeader />
+
+        <RecommendationPanel
+          error={recommendationError}
+          loading={recommendationLoading}
+          recommendation={recommendation}
+        />
 
         {loading && (
           <p className="passport-message">Loading your journey...</p>

--- a/frontend/src/pages/registerPage.jsx
+++ b/frontend/src/pages/registerPage.jsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { AuthShell } from "../components/auth/authShell.jsx";
 import { RegisterForm } from "../components/auth/registerForm.jsx";
 import { loginUser, registerUser } from "../services/authService.js";
+import { primeRecommendationCache } from "../services/recommendationService.js";
 import { saveAccessToken } from "../services/tokenStorage.js";
 
 export default function RegisterPage() {
@@ -22,6 +23,9 @@ export default function RegisterPage() {
         password: user.password,
       });
       saveAccessToken(auth.access_token);
+      await primeRecommendationCache().catch((err) => {
+        console.error("Failed to prime recommendations:", err);
+      });
       setSuccess("Conta criada com sucesso. Abrindo seu mapa.");
       window.location.replace("/map");
     } catch (requestError) {

--- a/frontend/src/services/recommendationCache.js
+++ b/frontend/src/services/recommendationCache.js
@@ -1,0 +1,30 @@
+const RECOMMENDATION_CACHE_KEY = "kulti_recommendation";
+
+export function readCachedRecommendation(token) {
+  if (!token) return null;
+
+  const rawValue = window.localStorage.getItem(RECOMMENDATION_CACHE_KEY);
+  if (!rawValue) return null;
+
+  try {
+    const cached = JSON.parse(rawValue);
+    if (cached?.token !== token) return null;
+    return cached.recommendation ?? null;
+  } catch {
+    window.localStorage.removeItem(RECOMMENDATION_CACHE_KEY);
+    return null;
+  }
+}
+
+export function saveCachedRecommendation(token, recommendation) {
+  if (!token || !recommendation) return;
+
+  window.localStorage.setItem(
+    RECOMMENDATION_CACHE_KEY,
+    JSON.stringify({ token, recommendation }),
+  );
+}
+
+export function clearCachedRecommendation() {
+  window.localStorage.removeItem(RECOMMENDATION_CACHE_KEY);
+}

--- a/frontend/src/services/recommendationService.js
+++ b/frontend/src/services/recommendationService.js
@@ -1,0 +1,25 @@
+import { apiRequest } from "./api.js";
+import { getAccessToken } from "./tokenStorage.js";
+import {
+  clearCachedRecommendation,
+  readCachedRecommendation,
+  saveCachedRecommendation,
+} from "./recommendationCache.js";
+
+export async function fetchRecommendations({ forceRefresh = false } = {}) {
+  const token = getAccessToken();
+
+  if (!forceRefresh) {
+    const cachedRecommendation = readCachedRecommendation(token);
+    if (cachedRecommendation) return cachedRecommendation;
+  }
+
+  const recommendation = await apiRequest("/recommendations");
+  saveCachedRecommendation(token, recommendation);
+  return recommendation;
+}
+
+export async function primeRecommendationCache() {
+  clearCachedRecommendation();
+  return fetchRecommendations({ forceRefresh: true });
+}

--- a/frontend/src/services/tokenStorage.js
+++ b/frontend/src/services/tokenStorage.js
@@ -1,4 +1,5 @@
 const ACCESS_TOKEN_KEY = "kulti_access_token";
+const RECOMMENDATION_CACHE_KEY = "kulti_recommendation";
 
 export function saveAccessToken(token) {
   window.localStorage.setItem(ACCESS_TOKEN_KEY, token);
@@ -10,4 +11,5 @@ export function getAccessToken() {
 
 export function clearAccessToken() {
   window.localStorage.removeItem(ACCESS_TOKEN_KEY);
+  window.localStorage.removeItem(RECOMMENDATION_CACHE_KEY);
 }

--- a/frontend/src/styles/passport.css
+++ b/frontend/src/styles/passport.css
@@ -275,6 +275,22 @@
 .recommendation-card .venue-detail-wishlist {
   z-index: 1;
 }
+
+@media (max-width: 800px) {
+  .recommendation-heading {
+    flex-direction: column;
+  }
+
+  .recommendation-card {
+    grid-template-columns: 1fr;
+  }
+
+  .recommendation-image {
+    aspect-ratio: 16 / 9;
+    height: auto;
+  }
+}
+
 /* STATES */
 
 .passport-message {

--- a/frontend/src/styles/passport.css
+++ b/frontend/src/styles/passport.css
@@ -182,6 +182,99 @@
 .recommendation-list::-webkit-scrollbar {
   display: none;
 }
+
+.recommendation-card {
+  align-items: stretch;
+  background: var(--color-bg-gallery);
+  border: 1px solid var(--color-border-birch);
+  border-radius: 8px;
+  color: inherit;
+  cursor: pointer;
+  display: grid;
+  flex: 0 0 100%;
+  grid-template-columns: minmax(220px, 0.42fr) minmax(0, 0.58fr);
+  min-height: 100px;
+  position: relative;
+  overflow: hidden;
+  padding: 0;
+  scroll-snap-align: start;
+  scroll-snap-stop: always;
+  text-align: left;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.recommendation-card:hover {
+  box-shadow: 0 8px 20px rgba(107, 83, 62, 0.11);
+  transform: translateY(-2px);
+}
+
+.recommendation-image {
+  height: 100%;
+  object-fit: cover;
+  width: 100%;
+}
+
+.recommendation-card-body {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  justify-content: center;
+  min-width: 0;
+  padding: 1.25rem;
+}
+
+.recommendation-category {
+  color: var(--color-primary-sage);
+  font-family: var(--font-ui);
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  margin-bottom: 0.4rem;
+  text-transform: uppercase;
+}
+
+.recommendation-name {
+  color: var(--color-text-obsidian);
+  font-family: var(--font-ui);
+  font-size: 1.15rem;
+  font-weight: 700;
+  line-height: 1.3;
+}
+
+.recommendation-address {
+  color: var(--color-text-charcoal);
+  font-family: var(--font-ui);
+  font-size: 0.82rem;
+  line-height: 1.4;
+  margin-top: 0.35rem;
+}
+
+.recommendation-justification {
+  color: var(--color-text-charcoal);
+  font-family: var(--font-ui);
+  font-size: 0.9rem;
+  line-height: 1.5;
+  margin-top: 0.75rem;
+}
+
+.recommendation-arrow {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 2;
+}
+
+.recommendation-arrow.carousel-arrow--left {
+  left: 0.5rem;
+}
+
+.recommendation-arrow.carousel-arrow--right {
+  right: 0.5rem;
+}
+
+.recommendation-card .venue-detail-wishlist {
+  z-index: 1;
+}
 /* STATES */
 
 .passport-message {

--- a/frontend/src/styles/passport.css
+++ b/frontend/src/styles/passport.css
@@ -89,6 +89,99 @@
   margin-top: 0.5rem;
 }
 
+/* RECOMMENDATIONS */
+
+.recommendation-panel {
+  background: var(--color-surface-white);
+  border: 1px solid var(--color-border-birch);
+  border-radius: 8px;
+  box-shadow: 0 4px 14px rgba(107, 83, 62, 0.08);
+  margin-bottom: 2rem;
+  padding: 1.25rem;
+}
+
+.recommendation-panel--muted {
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.recommendation-heading {
+  align-items: flex-start;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
+}
+
+.recommendation-kicker {
+  color: var(--color-primary-sage);
+  display: block;
+  font-family: var(--font-ui);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  margin-bottom: 0.25rem;
+  text-transform: uppercase;
+}
+
+.recommendation-title {
+  color: var(--color-text-obsidian);
+  font-family: var(--font-display);
+  font-size: 1.65rem;
+  font-weight: 600;
+  line-height: 1.15;
+  margin: 0;
+}
+
+.recommendation-badge {
+  background: var(--color-bg-gallery);
+  border: 1px solid var(--color-border-birch);
+  border-radius: 999px;
+  color: var(--color-text-charcoal);
+  flex: 0 0 auto;
+  font-family: var(--font-ui);
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.35rem 0.65rem;
+}
+
+.recommendation-badge--ai {
+  background: rgba(91, 121, 94, 0.12);
+  border-color: rgba(91, 121, 94, 0.22);
+  color: var(--color-primary-sage);
+}
+
+.recommendation-note,
+.recommendation-status,
+.recommendation-fallback {
+  color: var(--color-text-charcoal);
+  font-family: var(--font-ui);
+  font-size: 0.92rem;
+  line-height: 1.55;
+  margin: 0;
+}
+
+.recommendation-fallback {
+  margin-top: 0.5rem;
+}
+
+.recommendation-carousel {
+  margin-top: 1rem;
+  position: relative;
+}
+
+.recommendation-list {
+  display: flex;
+  gap: 0;
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  scroll-behavior: smooth;
+  scroll-snap-type: x mandatory;
+  scrollbar-width: none;
+}
+
+.recommendation-list::-webkit-scrollbar {
+  display: none;
+}
 /* STATES */
 
 .passport-message {

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -7,8 +7,9 @@ export default defineConfig({
   server: {
     proxy: {
       "/auth": "http://localhost:8000",
-      "/venues": "http://localhost:8000",
+      "/recommendations": "http://localhost:8000",
       "/records": "http://localhost:8000",
+      "/venues": "http://localhost:8000",
       "/wishlists": "http://localhost:8000"
     },
   },

--- a/start.sh
+++ b/start.sh
@@ -3,6 +3,12 @@ set -e
 
 trap 'kill 0' EXIT
 
+if [ -f .env ]; then
+  set -a
+  source .env
+  set +a
+fi
+
 echo "Starting database..."
 docker compose up -d
 


### PR DESCRIPTION
<!-- PR title must match branch type: docs: , feat: , fix: , refactor: , chore: -->

  ## Description
  Adds an AI-powered recommendation flow to the Passport page, with a backend route that builds cultural itineraries from user history and wishlist data, plus a frontend panel to display and cache the suggested route.

  ## Related User Story
  US #9  - Personalized AI route recommendations in Passport

  ## Changes
  - Added a `/recommendations` backend endpoint and recommendation service.
  - Added schemas for recommendation output and venue payloads.
  - Integrated Gemini-based itinerary generation with popularity fallback.
  - Added frontend recommendation cache and priming on login/register.
  - Rendered the recommendation panel in Passport with carousel arrows and AI/fallback badges.
  - Updated Passport styling for the recommendation card layout.
  - Set login token expiration to 1440 minutes.
  

  ## How to test


  ## Rollback plan
  - [x] Safe to revert (no migrations or data changes)
  - [ ] Requires manual intervention (describe below)
  - [ ] Database migration needs rollback
  - [x] Environment variables or config changes need reverting

  ## Screenshots (if applicable)

  ## Checklist
  - [x] Branch follows naming convention (`feature/`, `fix/`, `refactor/`, `docs/`, `chore/`)
  - [x] Code follows project standards
  - [x] Tested locally
  - [x] No errors in console/terminal
  - [x] Documentation updated (if needed)