### PR TITLE
fix: alembic reads DATABASE_URL from environment

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,3 +1,4 @@
+import os
 from logging.config import fileConfig
 
 from sqlalchemy import engine_from_config, pool
@@ -11,6 +12,9 @@ config = context.config
 
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
+
+if os.getenv("DATABASE_URL"):
+    config.set_main_option("sqlalchemy.url", os.environ["DATABASE_URL"])
 
 target_metadata = Base.metadata
 


### PR DESCRIPTION
Alembic was ignoring the `DATABASE_URL` env var and falling back to the hardcoded localhost URL in `alembic.ini`. This fix overrides `sqlalchemy.url` in `env.py` when the env var is present.